### PR TITLE
fix error in solution for data-types exercise 1d. calling typeof on a…

### DIFF
--- a/data-types/types-and-equality/src/solutions/1-solution.js
+++ b/data-types/types-and-equality/src/solutions/1-solution.js
@@ -35,7 +35,7 @@ const dataTypeD = () => {
   return typeof D;
 };
 // Assign the correct type to returnedDValue
-let returnedDValue = "null";
+let returnedDValue = "object";
 
 test("should have correct value for dataTypeD", () => {
   expect(dataTypeD() == returnedDValue).toBe(true);


### PR DESCRIPTION
The solution for exercise 1d in the Types & Equality course is incorrect. Calling typeof on a null value does not return "null", it returns "object", as described here https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#null