### PR TITLE
Updating TypeScript Generics exercise

### DIFF
--- a/typescript-basics/typescript-types/src/exercises/__tests__/exercise4.test.ts
+++ b/typescript-basics/typescript-types/src/exercises/__tests__/exercise4.test.ts
@@ -1,14 +1,17 @@
-import { addAllTogether, INITIAL_NUMBER, INITIAL_STRING } from "../exercise4";
+import { mash, NUMBER_TO_MASH, STRING_TO_MASH } from "../exercise4";
 
-test("It can add numbers together", () => {
-  expect(addAllTogether<number>([1, 2, 3], INITIAL_NUMBER)).toBe(6);
+test("It can mash a number key with a string value", () => {
+  const resultMap = new Map<number, string>();
+  resultMap.set(10, "Hello");
+  expect(mash<number, string>(NUMBER_TO_MASH, STRING_TO_MASH)).toMatchObject(
+    resultMap
+  );
 });
 
-test("It can append strings together", () => {
-  expect(
-    addAllTogether<string>(
-      ["Pineapple", "Is", "Good", "On", "Pizza"],
-      INITIAL_STRING
-    )
-  ).toBe("PineappleIsGoodOnPizza");
+test("It can mash a string key with a number value", () => {
+  const resultMap = new Map<string, number>();
+  resultMap.set("Hello", 10);
+  expect(mash<string, number>(STRING_TO_MASH, NUMBER_TO_MASH)).toMatchObject(
+    resultMap
+  );
 });

--- a/typescript-basics/typescript-types/src/exercises/exercise4.ts
+++ b/typescript-basics/typescript-types/src/exercises/exercise4.ts
@@ -16,9 +16,9 @@ Bonus Exercise
 💡 and return a single Map() where the key
 💡 is the first param, and the value is the second param. 
 
-Example:
-mash("hello", 123) -> {hello: 123}
-zip([2, 3, 6], [5, 4, 3]) -> [[2, 5], [3, 4], [6, 3]]
+💡 Example:
+💡 mash<string, number>("hello", 123) -> {hello: 123}
+💡 mash<number, string>(123, "test") -> {123: "test"}
 
 💡 By using generics, we can confirm that the first input
 💡 param is the same type as the output key, and the second
@@ -27,7 +27,7 @@ zip([2, 3, 6], [5, 4, 3]) -> [[2, 5], [3, 4], [6, 3]]
 💡 a good use case for generics, which is to 
 💡 help developers confirm that the input type
 💡 and output type are of the same time, without
-💡 that type having to be explicityly defined. 
+💡 that type having to be explicitly defined. 
 Arrow functions & Generics: https://stackoverflow.com/a/45576880
  */
 

--- a/typescript-basics/typescript-types/src/exercises/exercise4.ts
+++ b/typescript-basics/typescript-types/src/exercises/exercise4.ts
@@ -9,25 +9,37 @@ Bonus Exercise
 🛠️ on the way the function is typed when it is 
 🛠️ invoked.
 
-💡 Update this function to leverage generics
-💡 A developer should be able to add together
-💡 different types, such as strings or numbers
-Arrow functions & Generics: https://stackoverflow.com/a/45576880
+💡 Update this function to leverage generics!
+💡 A developer should be able to "mash" together
+💡 two items of different types, such as strings or numbers
+💡 this mash function should take in params
+💡 and return a single Map() where the key
+💡 is the first param, and the value is the second param. 
 
-Take a look at the test file to see how Generics
-are leveraged in the implemenation of addAllTogether
+Example:
+mash("hello", 123) -> {hello: 123}
+zip([2, 3, 6], [5, 4, 3]) -> [[2, 5], [3, 4], [6, 3]]
+
+💡 By using generics, we can confirm that the first input
+💡 param is the same type as the output key, and the second
+💡 input is the same type as the output value,
+💡 no matter what these values are! This shows
+💡 a good use case for generics, which is to 
+💡 help developers confirm that the input type
+💡 and output type are of the same time, without
+💡 that type having to be explicityly defined. 
+Arrow functions & Generics: https://stackoverflow.com/a/45576880
  */
 
 // After updating the function with Generics, please update
-// this value to 0 for testing purposes
-export const INITIAL_NUMBER = undefined;
+// this value to 10 for testing purposes
+export const NUMBER_TO_MASH = undefined;
 // After updating the function with Generics, please update
-// this value to "" for testing purposes
-export const INITIAL_STRING = undefined;
+// this value to "Hello" for testing purposes
+export const STRING_TO_MASH = undefined;
 
-export const addAllTogether = (
-  array: Array<number>,
-  initialValue: number
-): number => {
-  return array.reduce((sum, value) => sum + value, <any>initialValue);
+export const mash = (key, value) => {
+  const map = new Map();
+  map.set(key, value);
+  return map;
 };

--- a/typescript-basics/typescript-types/src/solutions/exercise4.ts
+++ b/typescript-basics/typescript-types/src/solutions/exercise4.ts
@@ -1,6 +1,8 @@
-export const INITIAL_NUMBER = 0;
-export const INITIAL_STRING = "";
+export const NUMBER_TO_MASH = 10;
+export const STRING_TO_MASH = "Hello";
 
-export const addAllTogether = <T>(array: Array<T>, initialValue: T): T => {
-  return array.reduce((sum, value) => sum + value, <any>initialValue);
+export const mash = <S, T>(key: S, value: T): Map<S, T> => {
+  const map = new Map<S, T>();
+  map.set(key, value);
+  return map;
 };


### PR DESCRIPTION
Got feedback from teammates that the Generics exercise was not super clear. Changed the exercise to remove the confusing `<any>` from the reduce, and focused the explanation on the advantage of Generics (that you can make sure that the input types and output types are in line with each other).